### PR TITLE
Add liaison for Trac Data Analytics project

### DIFF
--- a/liason-program/liason-assignments.md
+++ b/liason-program/liason-assignments.md
@@ -22,7 +22,7 @@
 | Spring Bot | Matt Bain | |
 | Symphony | | |
 | TimeBase | Vincent Caldeira | |
-| Trac Data Analytics Platform | | |
+| Trac Data Analytics Platform | Vincent Caldeira | |
 | TraderX | Peter Smulovics | |
 | Vuu | John Arroyo | |
 | Waltz | John Arroyo | |


### PR DESCRIPTION
As discussed with @eddie-knight proposing to take over the liaison role for Trac Data Analytics project