### PR TITLE
Updated original TOC responsibilities with pointers to existing processes and documentation

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -22,7 +22,7 @@ The voting process is [described on this page](elections.md).
 
 ## Responsibilities
 
-The responsibilities of this group, together with the processes we have put in place to support them, are [detailed on this page](operations.md).
+The responsibilities of this group, together with the processes we have put in place to support them, are [detailed on this page](operations/governance.md#responsibilities).
 
 ## Ways of Working
 
@@ -36,9 +36,7 @@ To support ongoing work, we use the following communication channels:
  - We have ad-hoc meetings as and when they are needed. These will not be minuted.
 
 ### Meetings
-The TOC meets weekly, alternating between:
-- Tuesdays, 8:00 AM EST  *This is a private meeting only accessible to the FINOS team and TOC members.*
-- Wednesdays, 12:00 PM EST - [https://zoom.us/j/93181085065](https://zoom.us/j/93181085065?pwd=cys5NHRqcWFZaG9qdlB4SlR2Zjh3UT09) (Passcode: 331179) *This is a public meeting accessible to anyone from the FINOS community.*
+The TOC meets bi-weekly on Wednesdays, 12:00 PM EST - [https://zoom.us/j/93181085065](https://zoom.us/j/93181085065?pwd=cys5NHRqcWFZaG9qdlB4SlR2Zjh3UT09) (Passcode: 331179) *This is a public meeting accessible to anyone from the FINOS community.*
 
 ### Meeting minutes
 All meetings minutes are available as GitHub issues - https://github.com/finos/technical-oversight-committee/issues?q=is:issue+label:meeting+ ; those open, refer to meeting minutes that haven't been completed or reviewed yet.

--- a/operations/governance.md
+++ b/operations/governance.md
@@ -43,22 +43,26 @@ Chairs are appointed by the TOC to one-year terms beginning with the vacancy of 
 
 ### Responsibilities of the Group
 
-Accountable to the Governing Board, the TOC as a group is responsible to:
+The key responsibilities of the TOC are tabulated below:
 
-- Respond to project applications and promotion requests
-- Engage with incubating and graduated projects
-- Assess, promote, and facilitate cross-project synergies
-- Provide technical guidance and support for project lifecycles
-- Collaborate with the Governing Board to align strategic goals
-- Mentor newly elected TOC members
-- Capture decisions and outcomes in the TOC GitHub repository
-
-In a regular cadence, the TOC is responsible to:
-
-- For each OSFF, recruit or approve project-related presentations, project demos, and project booths
-- Review existing criteria for project evaluation and promotion at least annually
-- Examine the FINOS project landscape to highlight gaps or potential for additions or removals at least annually
-- Review and update the TOC governance documentation at least annually
+| **TOC Responsibilities** | **Outcome** | **Frequency** | **Resources / Process** |
+| - | - | - | - | 
+| **Landscape Ownership** |
+| Solicit and recommend cross-project synergies                              | Review project landscape and recommend                                                                                | Quarterly    | Invite relevant [Project Maintainers](https://groups.google.com/a/finos.org/g/finos-project-maintainers) to join TOC meetings.
+| Evolve technical governance, security standards, and best practices  |                                                                                                                       | Twice a year | Propose changes via PR to [FINOS Community Website](https://community.finos.org/)
+| Provide impartial and knowledge-based input into technical disputes        | Provide technical recommendations and next steps for dispute resolution and community messaging/engagement            | As needed    | Use [TOC Private List](https://lists.finos.org/g/toc-private) for confidential conversations not suitable to general public.
+| Review of project health                                                   | Review project activity and recommend actions as necessary                                                            | Quarterly    | Monitor [FINOS LFX Insight Dashboard](https://insights.lfx.linuxfoundation.org/foundation/finos)
+| Evolve the overall landscape                                               | Examine the FINOS project landscape and highlight gaps or potential for additions or removals                         | Twice a year | Propose changes to the [FINOS Landscape](https://landscape.finos.org/)
+| Recommend evolution of lifecycle criteria                            | Review existing criteria and recommend potential changes or assert continuation as is.                                | Annually     | Propose PRs to [Project Lifecycle](https://community.finos.org/docs/governance/software-projects/project-lifecycle/)
+| Recommend and approve lifecycle transitions                            | Evaluate and respond to submitted proposals on monthly basis                                                          | As needed    | [Project Activations](#project-activations) |
+| **Landscape growth** |
+| Review and approve contributions                                           | Review new contribution proposals and provide timely recommendations and feedback                                     | As needed    | [Project Contributions](#project-contributions) |
+| Assist FINOS in promote new contributions                                  | Engage with community to communicate value of projects and document potential use cases                               | As needed    | Subscribe and engage with [FINOS Community List](http://groups.google.com/a/community) and in [FINOS Community Repo](https://github.com/finos/community)
+| Assist FINOS in nurturing new project contributions                        | Identify opportunities to associate existing open source projects with the FSI community; recommend new projects      | As needed    | Propose ideas to [FINOS Leadership](leadership@finos.org)
+| **FINOS Governing Board & Strategic interaction** |
+| Provide a TOC liaison for each FINOS strategic initiative    | Engage with Executive Sponsors to identify use cases and promote implementation of strategically-significant projects | Quarterly    | TOC Chair source liaison and report to Governing Board
+| Report to the board                                                        | Engage in annual strategy planning; provide a quarterly report of TOC activities and decisions                        | Quarterly    | [Board Reporting](#board-reporting) |
+| OSFF active participation                               | Participate in program committee, and recruit / recommend approve project-related presentations, project demos, and project booths                        | Twice a year    | Interact via [OSFF alias](ossf@finos.org) |
 
 > [!NOTE]
 > The Chair is accountable for ensuring that the above responsibilities are fulfilled by the group, with equitable involvement from all members.
@@ -94,6 +98,9 @@ In a regular cadence, the TOC is responsible to:
 - Propose and onboard a Chair replacement before transitioning out
 
 ---
+## Processes
+
+TOC activities are managed in GitHub via the [TOC Backlog](https://github.com/orgs/finos/projects/39), which is fed by the Community, the FINOS team and owned by the TOC chair. Below a list of transparently documented processes the TOC follows:
 
 ## Decision-Making and Voting
 
@@ -106,6 +113,40 @@ In a regular cadence, the TOC is responsible to:
 - To qualify as a voting member, members must have attended two of the last three TOC meetings
 - A majority vote is required to pass proposals
 - The Chair must withhold all vote participation except to act as a tie-breaker
+
+
+### Project Contributions
+
+ - Project contributions are submitted via the [FINOS community project](https://github.com/finos/community) as issues, according to the [FINOS contribution process](https://community.finos.org/docs/governance/software-projects/contribution/).
+ - The FINOS team perform initial validation, including completeness of the [Incubation checklist](https://community.finos.org/docs/governance/software-projects/stages/incubating/#incubating-lifecycle-checklist) requirements, and encourage initial socialization with the FINOS community
+ - FINOS team indicates contributions are ready for TOC via the `ready-for-toc` label, adding them to the [TOC Backlog](https://github.com/orgs/finos/projects/39) and assigning tho the current TOC chair
+ - TOC evaluates contribution using the [TOC contribution principles](https://github.com/finos/technical-steering-committee/blob/master/contribution-principles.md) and the [Incubation checklist](https://community.finos.org/docs/governance/software-projects/stages/incubating/#incubating-lifecycle-checklist)
+ - TOC assigns a TOC member and / or ask for contributors to present a TOC and answer questions / provide additional evidence.
+ - TOC will indicate the outcome (approve / rejected), providing an explanation narrative, directly on the issue itself
+ - FINOS team proceed with further onboarding steps, including evaluating and addressing [Contribution Compliance Requirements](https://community.finos.org/docs/governance/Software-Projects/contribution-compliance-requirements).
+
+### Project Activations
+
+ - Project activations are submitted via the [FINOS community project](https://github.com/finos/community) as issues, according to the [FINOS Activation Process](https://community.finos.org/docs/governance/software-projects/stages/active/#initiating-activation)
+ - The FINOS team perform initial validation, including completeness of the [Activation checklist](https://community.finos.org/docs/governance/software-projects/stages/active/#activation-checklist) requirements
+ - FINOS team indicates contributions are ready for TOC input via the `ready-for-toc` label, adding them to the [TOC Backlog](https://github.com/orgs/finos/projects/39) and assigning tho the current TOC chair
+- TOC evaluates activation using the [Activation checklist](https://community.finos.org/docs/governance/software-projects/stages/active/#activation-checklist)
+-  TOC assigns a TOC member to evaluate the activation and / or ask for contributors to present a TOC and answer questions / provide additional evidence.
+ - A TOC member is assigned to evaluate the activation
+ - The TOC member will provides particular scrutiny and exercise discretion on, but not limited to, these items:
+   - Usefulness - is it clear what business problem this project is addressing? What are the use cases that it helps solve? What are its main benefits?
+   - Community - how is the project being used and consumed? There may be different ways for firms/individuals to consume and contribute to a project, more or less relevant to assess its maturity.
+   - Progress - is the project following the publicly shared roadmap?
+- TOC will indicate the outcome (approve / rejected), providing an explanation narrative, directly on the issue itself and assigns a FINOS team members for further processing
+ - FINOS team proceed accordingly with further steps, including applying the [active badge](https://community.finos.org/docs/governance/software-projects/stages/active/#badge) in case of successful activation  
+
+### Board reporting
+
+ - It is the responsibility of the Chair to provide regular and timely reports for the Governing Board before each Governing Board meeting. Ideally this should contain:
+   - Report on overall project landscape health
+   - Stats on activity of TOC itself
+   - High level overview of initiatives TOC is undertaking
+   - Any other criticality or recommendation for the Governing Board
 
 ---
 


### PR DESCRIPTION
@finos/toc As a proper rookie,  I missed the window to review https://github.com/finos/technical-oversight-committee/pull/198. 

But I did have this PR open in my tabs for a while, with the idea of adding a lot of links to existing documentation and processes so FINOS team, TOC and community can have actionable input on how to best perform their role. 

Given the many recent changes in the FINOS team, the TOC and the fast growing nature of the FINOS community (which is way more mature than time ago), I figured it would be useful to provide color on what the original intent of the Governing Board responsibilities was and update them to how FINOS operates now (e.g. strategic initiatives).

That being said, I realize it's a lot more verbose and I hate to have you do another review. So if you feel like just dropping this, please take this just as input of any contributor (ED hat off) and I might raise a more simplified one or you might decide to pick and choose (e.g. from the processes column of the responsibilities, which I think has a lot of useful pointers, and frankly would make the FINOS time much easier if you could follow those).

Thanks and hope it helps!