### PR TITLE
Add TOC candidacy nomination issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/toc-candidacy.yml
+++ b/.github/ISSUE_TEMPLATE/toc-candidacy.yml
@@ -52,3 +52,18 @@ body:
       placeholder: Mention specific initiatives or strategic areas you'd like to champion.
     validations:
       required: false
+
+  - type: checkboxes
+    id: confirmation
+    attributes:
+      label: Confirmation & Commitment
+      description: Please review and confirm your agreement to the TOC requirements.
+      options:
+        - label: I have reviewed the TOC responsibilities and ways of working. With my candidacy, I confirm that I would be volunteering and assisting on the work items assigned to me.
+          required: true
+
+  - type: markdown
+    attributes:
+      value: |
+        ---
+        💡 **Need help?** Feel free to contact toc@lists.finos.org if you have any questions about the election process or the TOC.

--- a/.github/ISSUE_TEMPLATE/toc-candidacy.yml
+++ b/.github/ISSUE_TEMPLATE/toc-candidacy.yml
@@ -1,0 +1,54 @@
+name: TOC Candidacy Nomination
+description: Submit your candidacy for the Technical Oversight Committee (TOC) election.
+title: "[TOC Candidacy]: <Your Name>"
+labels: ["toc-election"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thank you for submitting your candidacy for the TOC. Please fill out the details below completely.
+
+  - type: input
+    id: affiliation
+    attributes:
+      label: Affiliation
+      description: Name of the company you work for. If not applicable, put "Independent".
+      placeholder: e.g., Acme Corp / Independent
+    validations:
+      required: true
+
+  - type: textarea
+    id: qualifications
+    attributes:
+      label: Qualifications for candidacy
+      description: Are you a member OR active contributor of project x, y, z OR both?
+      placeholder: |
+        - Maintainer of Project X
+        - Active contributor to Project Y
+    validations:
+      required: true
+
+  - type: textarea
+    id: bio
+    attributes:
+      label: Bio
+      description: Provide relevant information about yourself that you would like to be considered during the election.
+      placeholder: Tell the community about your background, experience, and history with the ecosystem...
+    validations:
+      required: true
+
+  - type: textarea
+    id: ecosystem-impact
+    attributes:
+      label: What impact do you hope to have on the ecosystem during your tenure as TOC member?
+      placeholder: Share your vision, goals, and what you hope to achieve...
+    validations:
+      required: true
+
+  - type: textarea
+    id: finos-initiatives
+    attributes:
+      label: Are there any FINOS Strategic Initiatives you would be interested in working on?
+      placeholder: Mention specific initiatives or strategic areas you'd like to champion.
+    validations:
+      required: false


### PR DESCRIPTION
This file defines the issue template for submitting candidacies for the Technical Oversight Committee (TOC) election, including fields for affiliation, qualifications, bio, ecosystem impact, and FINOS initiatives.

The issue creation process can be tested on my fork: https://github.com/TheJuanAndOnly99/technical-oversight-committee/issues/new?template=toc-candidacy.yml