### PR TITLE
Update voting process reference in elections.md

### DIFF
--- a/operations/processes/elections/elections.md
+++ b/operations/processes/elections/elections.md
@@ -21,7 +21,7 @@ Candidates are expected to be:
 
 A TOC member publicly opens candidacies by sending a notice using the email template provided [here](elections-candidacy-template.md).
 
-Similarly to [Governing Board elections](https://community.finos.org/docs/governance/board-election), the voting process is carried out using a [ranked-choice](https://opavote.com/methods/ranked-choice-voting) instant-runoff voting process by FINOS staff using the [Linux Foundation Project Control Center Voting](https://docs.linuxfoundation.org/lfx/project-control-center/v2-latest-version/collaborations/voting-feature) feature.
+Similarly to [Governing Board elections](https://community.finos.org/docs/governance/board-election), the voting process is carried out using a [ranked-choice instant-runoff](https://docs.linuxfoundation.org/lfx/project-control-center/v2-latest-version/collaborations/voting-feature#instant-runoff) voting process by FINOS staff using the [Linux Foundation Project Control Center Voting](https://docs.linuxfoundation.org/lfx/project-control-center/v2-latest-version/collaborations/voting-feature) feature.
 
 If there are both Board and TOC elected seat open, the voting process will follow this order:
 

--- a/operations/processes/elections/elections.md
+++ b/operations/processes/elections/elections.md
@@ -21,7 +21,7 @@ Candidates are expected to be:
 
 A TOC member publicly opens candidacies by sending a notice using the email template provided [here](elections-candidacy-template.md).
 
-Similarly to [Governing Board elections](https://community.finos.org/docs/governance/board-election), the voting process is carried out using a [ranked-choice](https://opavote.com/methods/ranked-choice-voting) instant-runoff voting process by FINOS staff using the [Opavote](https://opavote.com/) tool.
+Similarly to [Governing Board elections](https://community.finos.org/docs/governance/board-election), the voting process is carried out using a [ranked-choice](https://opavote.com/methods/ranked-choice-voting) instant-runoff voting process by FINOS staff using the [Linux Foundation Project Control Center Voting](https://docs.linuxfoundation.org/lfx/project-control-center/v2-latest-version/collaborations/voting-feature) feature.
 
 If there are both Board and TOC elected seat open, the voting process will follow this order:
 

--- a/operations/processes/elections/elections.md
+++ b/operations/processes/elections/elections.md
@@ -21,7 +21,7 @@ Candidates are expected to be:
 
 A TOC member publicly opens candidacies by sending a notice using the email template provided [here](elections-candidacy-template.md).
 
-Similarly to [Governing Board elections](https://community.finos.org/docs/governance/board-election), the voting process is carried out using a [ranked-choice instant-runoff](https://docs.linuxfoundation.org/lfx/project-control-center/v2-latest-version/collaborations/voting-feature#instant-runoff) voting process by FINOS staff using the [Linux Foundation Project Control Center Voting](https://docs.linuxfoundation.org/lfx/project-control-center/v2-latest-version/collaborations/voting-feature) feature.
+Similarly to [Governing Board elections](https://community.finos.org/docs/governance/board-election), the voting process is carried out by FINOS staff using the [Linux Foundation Project Control Center Voting](https://docs.linuxfoundation.org/lfx/project-control-center/v2-latest-version/collaborations/voting-feature) feature, utilizing a ranked-choice [Instant Runoff](https://docs.linuxfoundation.org/lfx/project-control-center/v2-latest-version/collaborations/voting-feature#instant-runoff) process for single winners or [Meek STV](https://docs.linuxfoundation.org/lfx/project-control-center/v2-latest-version/collaborations/voting-feature#meek-stv) when electing multiple winners.
 
 If there are both Board and TOC elected seat open, the voting process will follow this order:
 


### PR DESCRIPTION
All future votes will be run via the Linux Foundations Project Control Center [Voting feature](https://docs.linuxfoundation.org/lfx/project-control-center/v2-latest-version/collaborations/voting-feature) as such this change updates the voting process reference to include the change.

I would also suggest that we consider using [Meek STV](https://docs.linuxfoundation.org/lfx/project-control-center/v2-latest-version/collaborations/voting-feature#meek-stv) instead of [Instant Runoff](https://docs.linuxfoundation.org/lfx/project-control-center/v2-latest-version/collaborations/voting-feature#meek-stv#instant-runoff) when we need to elect multiple winners as it's better suited for that purpose. Let me know what you think.